### PR TITLE
Issue 109 respect min value , not hardcode

### DIFF
--- a/src/module/component/mat-password-strength/mat-password-strength.component.ts
+++ b/src/module/component/mat-password-strength/mat-password-strength.component.ts
@@ -87,7 +87,7 @@ export class MatPasswordStrengthComponent implements OnInit, OnChanges {
   }
 
   private _containAtLeastEightChars(): boolean {
-    this.containAtLeastEightChars = this.password.length >= 8;
+    this.containAtLeastEightChars = this.password.length >= this.min;
     return this.containAtLeastEightChars;
   }
 


### PR DESCRIPTION
This should fix issue https://github.com/angular-material-extensions/password-strength/issues/109 

replace hardcoded value with input